### PR TITLE
Update canvas-snippet.json in default snippet, changed the spell mistake

### DIFF
--- a/snippets/canvas-snippet.json
+++ b/snippets/canvas-snippet.json
@@ -85,7 +85,7 @@
       " *  utils.js - <https://github.com/christopher4lis/canvas-boilerplate/blob/master/src/js/utils.js>",
       " *  @function randomIntFromRange Picks a random integer within a range",
       " *  @function randomColor Picks a random color",
-      " *  @function dispatch Find the distance between two points",
+      " *  @function distance Find the distance between two points",
       " **/ ",
       "",
       "function randomIntFromRange(min, max) {",


### PR DESCRIPTION
Changed the spell mistake, instead of "dispatch", changed it to "distance" I guess that's the function name that you were trying to put over there. : )